### PR TITLE
Upgrade Mockito to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes mockito error with Java >= 17:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.redislabs.university.RU102J.resources.MeterReadingResourceTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.047 sec <<< FAILURE!
com.redislabs.university.RU102J.resources.MeterReadingResourceTest  Time elapsed: 0.047 sec  <<< ERROR!
java.lang.ExceptionInInitializerError
	at org.mockito.cglib.core.KeyFactory$Generator.generateClass(KeyFactory.java:167)
```